### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * Completely open-source and free: Flut Renamer is entirely open-source and contains no advertisements or in-app purchases, allowing you to use it freely at any time.
 * Cross-platform compatibility: Built on the Flutter framework, Flut Renamer can run on multiple operating systems, enabling you to use it anytime, anywhere.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sun-jiao/flut-renamer&type=Date)](https://star-history.com/#sun-jiao/flut-renamer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sun-jiao/flut-renamer&type=Date)](https://star-history.dera.page/#sun-jiao/flut-renamer&Date)
 
 ## Install
 ### Android


### PR DESCRIPTION
The star history chart in the README is broken. The original chart service can no longer access the GitHub stargazer API, so the chart no longer loads. This change points the chart to a new domain that provides the same chart without requiring an API token, restoring the chart for everyone. Please merge this fix as soon as possible.